### PR TITLE
feat(base64)!: support `data:` url first

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Convert from any value to [ArrayBuffer][ArrayBuffer]
 
 ### `assertBase64(input, opts?)`
 
-Assert that input is an instance of [Text][Text] and matches the [Base64][Base64] pattern or throw a `TypeError`.
+Assert if input matches the [Base64][Base64] data URL (data:[<mediatype>][;base64],<data>) or throw a `TypeError`.
 
 ### `base64ToArrayBuffer(string, base64Options?)`
 
@@ -216,9 +216,9 @@ Convert from [Base64][Base64] to [Text][Text]
 
 Convert from [Base64][Base64] to [Uint8Array][Uint8Array]
 
-### `isBase64(input, base64Options?)`
+### `isBase64DataURL(input)`
 
-Test if input is string and matches the [Base64][Base64] pattern and return `true` or `false`.
+Test if input matches the [Base64][Base64] data URL (data:[<mediatype>][;base64],<data>) and return `true` or `false`.
 
 ### `toBase64(input)`
 

--- a/src/data-types/_utils.ts
+++ b/src/data-types/_utils.ts
@@ -20,5 +20,7 @@ export function _base64Encode(data: Uint8Array, opts?: Base64Options): Base64 {
       .replace(/\//g, "_")
       .replace(/=+$/, "");
   }
-  return opts?.dataURL === false ? encoded : `data:;base64,${encoded}`;
+  return opts?.dataURL === false
+    ? encoded
+    : `data:${opts?.type || ""};base64,${encoded}`;
 }

--- a/src/data-types/_utils.ts
+++ b/src/data-types/_utils.ts
@@ -12,16 +12,13 @@ export function assertType<T>(
   }
 }
 
-export function _base64Encode(
-  data: Uint8Array,
-  base64Options?: Base64Options,
-): Base64 {
+export function _base64Encode(data: Uint8Array, opts?: Base64Options): Base64 {
   let encoded = btoa(String.fromCodePoint(...data));
-  if (base64Options?.urlSafe) {
+  if (opts?.urlSafe) {
     encoded = encoded
       .replace(/\+/g, "-")
       .replace(/\//g, "_")
       .replace(/=+$/, "");
   }
-  return encoded;
+  return opts?.dataURL === false ? encoded : `data:;base64,${encoded}`;
 }

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,5 +1,6 @@
 import {
   isArrayBuffer,
+  isBase64DataURL,
   isBlob,
   isDataView,
   isNodeStream,
@@ -20,11 +21,11 @@ const detectors: [DataTypeName, (input: unknown) => boolean][] = [
   ["DataView", isDataView],
   ["ReadableStream", isReadableStream],
   ["Response", isResponse],
-  // Typeof checkers
-  ["Text", isText],
   // More checkers
   ["NodeStream", isNodeStream],
   ["NumberArray", isNumberArray],
+  ["Base64", isBase64DataURL],
+  ["Text", isText],
 ];
 
 export function detectType(input: DataType): DataTypeName {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,4 +40,4 @@ export type DataTypeMap<T extends DataTypeName> = _DataTypeMap[T];
 
 export type Base64 = string;
 
-export type Base64Options = { urlSafe?: boolean };
+export type Base64Options = { urlSafe?: boolean; dataURL?: boolean };

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,4 +40,8 @@ export type DataTypeMap<T extends DataTypeName> = _DataTypeMap[T];
 
 export type Base64 = string;
 
-export type Base64Options = { urlSafe?: boolean; dataURL?: boolean };
+export type Base64Options = {
+  urlSafe?: boolean;
+  dataURL?: boolean;
+  type?: string;
+};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -22,7 +22,7 @@ const fixtureByes = new TextEncoder().encode(fixtureText);
 const fixtures: Record<DataTypeName, () => DataType> = {
   ArrayBuffer: () => fixtureByes.buffer,
   Base64: () =>
-    "data:text/plain;base64," + btoa(String.fromCodePoint(...fixtureByes)),
+    `data:text/plain;base64,${btoa(String.fromCodePoint(...fixtureByes))}`,
   Blob: () => new Blob([fixtureByes]),
   DataView: () => new DataView(fixtureByes.buffer),
   NumberArray: () => [...fixtureByes],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -21,7 +21,8 @@ const fixtureByes = new TextEncoder().encode(fixtureText);
 
 const fixtures: Record<DataTypeName, () => DataType> = {
   ArrayBuffer: () => fixtureByes.buffer,
-  Base64: () => btoa(String.fromCodePoint(...fixtureByes)),
+  Base64: () =>
+    "data:text/plain;base64," + btoa(String.fromCodePoint(...fixtureByes)),
   Blob: () => new Blob([fixtureByes]),
   DataView: () => new DataView(fixtureByes.buffer),
   NumberArray: () => [...fixtureByes],
@@ -57,9 +58,7 @@ describe("detectType", () => {
     describe(typeName, () => {
       const input = fixtures[typeName]();
       it(`should detect ${typeName} from ${input}`, () => {
-        expect(detectType(input)).toBe(
-          typeName === "Base64" ? "Text" : typeName,
-        );
+        expect(detectType(input)).toBe(typeName);
       });
     });
   }
@@ -73,7 +72,7 @@ describe("convertTo", () => {
         const input = fixtures[from]();
         it(`should convert ${from} to ${to}`, async () => {
           const output = await convertTo(to, input);
-          expect(detectType(output)).toBe(to === "Base64" ? "Text" : to);
+          expect(detectType(output)).toBe(to);
         });
       });
     }
@@ -88,7 +87,7 @@ describe("toType", () => {
         const input = fixtures[from]();
         it(`should convert ${from} to ${to}`, async () => {
           const output = await convertFunctions[`to${to}`](input);
-          expect(detectType(output)).toBe(to === "Base64" ? "Text" : to);
+          expect(detectType(output)).toBe(to);
         });
       });
     }


### PR DESCRIPTION
Continuation to #8

With this PR, we both detect/support and by default encode base64 values with `data:;base64,` base ([mdn](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)) this way it is both URL and Web-compatible and also we support detection type automatically.

 