### PR TITLE
fix(base64): chunk Uint8Array encoding to prevent stack overflow for large inputs

### DIFF
--- a/src/data-types/_utils.ts
+++ b/src/data-types/_utils.ts
@@ -13,7 +13,15 @@ export function assertType<T>(
 }
 
 export function _base64Encode(data: Uint8Array, opts?: Base64Options): Base64 {
-  let encoded = btoa(String.fromCodePoint(...data));
+  // Process in chunks to avoid "Maximum call stack size exceeded" when data is
+  // large (e.g. PDFs, images). Spreading a huge array as function arguments
+  // exhausts the JS engine's call-stack argument limit (~65 536 args).
+  const CHUNK_SIZE = 0xff_ff;
+  let str = "";
+  for (let i = 0; i < data.length; i += CHUNK_SIZE) {
+    str += String.fromCodePoint(...data.subarray(i, i + CHUNK_SIZE));
+  }
+  let encoded = btoa(str);
   if (opts?.urlSafe) {
     encoded = encoded
       .replace(/\+/g, "-")

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,6 +12,7 @@ import {
   toResponse,
   toText,
   toUint8Array,
+  uint8ArrayToBase64,
   uint8ArrayToText,
 } from "../src";
 import type { DataType, DataTypeName } from "../src/types";
@@ -120,4 +121,14 @@ describe("Base64", async () => {
       });
     });
   }
+
+  it("should encode large Uint8Array (>65535 bytes) without stack overflow", () => {
+    // String.fromCodePoint(...data) crashes when data.length exceeds the JS
+    // engine's max argument count. Use a 200 kB array to reliably reproduce.
+    const large = new Uint8Array(200_000).fill(42);
+    expect(() => uint8ArrayToBase64(large, { dataURL: false })).not.toThrow();
+    const encoded = uint8ArrayToBase64(large, { dataURL: false });
+    // btoa of 200 000 bytes of 0x2A ('*') → predictable base64 output length
+    expect(encoded.length).toBe(Math.ceil(200_000 / 3) * 4);
+  });
 });


### PR DESCRIPTION
Closes #41

## Problem

`_base64Encode` converts a `Uint8Array` to a base64 string with:

```ts
btoa(String.fromCodePoint(...data))
```

The spread operator passes every byte as a separate function argument. JavaScript engines have a hard limit on the number of arguments a function call can receive (~65 536 in V8/SpiderMonkey). For large inputs such as PDF pages or images, this reliably throws:

```
RangeError: Maximum call stack size exceeded
```

The bug only manifests in resource-constrained environments (small cloud containers, edge workers) where the engine's argument limit is hit sooner, which is why it works locally but crashes on DigitalOcean's smallest app tier.

## Fix

Process the array in 65 535-byte chunks, building the binary string incrementally before passing it to `btoa`:

```ts
const CHUNK_SIZE = 0xffff;
let str = "";
for (let i = 0; i < data.length; i += CHUNK_SIZE) {
  str += String.fromCodePoint(...data.subarray(i, i + CHUNK_SIZE));
}
let encoded = btoa(str);
```

This is the standard pattern recommended by MDN for this exact scenario. It is fully cross-platform — no `Buffer`, no Node.js-only APIs — so it works in browsers, Deno, Cloudflare Workers, and Bun too.

## Test

Added a regression test that encodes a 200 kB `Uint8Array` (well above the 65 535-arg threshold) and asserts:
1. it does not throw
2. the output length matches the expected base64 size for the input


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public function to encode Uint8Array data to base64.

* **Bug Fixes**
  * Reworked the encoder to process large binary payloads safely, preventing stack/overflow issues and ensuring correct output length for very large inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->